### PR TITLE
Tablet/desktop responsive design.

### DIFF
--- a/ThunderStrikes/angular.json
+++ b/ThunderStrikes/angular.json
@@ -29,6 +29,7 @@
               "src/manifest.webmanifest",
               "src/manifest.webmanifest",
               "src/manifest.webmanifest",
+              "src/manifest.webmanifest",
               "src/manifest.webmanifest"
             ],
             "styles": [
@@ -100,6 +101,7 @@
             "assets": [
               "src/favicon.ico",
               "src/assets",
+              "src/manifest.webmanifest",
               "src/manifest.webmanifest",
               "src/manifest.webmanifest",
               "src/manifest.webmanifest",

--- a/ThunderStrikes/src/app/modules/individual-movie/components/cast-and-crew/cast-and-crew.component.html
+++ b/ThunderStrikes/src/app/modules/individual-movie/components/cast-and-crew/cast-and-crew.component.html
@@ -5,8 +5,8 @@
             src="{{actor.profile_path}}"
             alt="Portrait of {{actor.name}}"
             loading="lazy" 
-            width="500" 
-            height="750"
+            width="{{actorImageSize.width}}" 
+            height="{{actorImageSize.height}}"
         >
         <p>{{actor.name}}</p>
     </li>

--- a/ThunderStrikes/src/app/modules/individual-movie/components/cast-and-crew/cast-and-crew.component.scss
+++ b/ThunderStrikes/src/app/modules/individual-movie/components/cast-and-crew/cast-and-crew.component.scss
@@ -2,26 +2,34 @@
     display: flex;
     flex-direction: column;
     gap: 1vh;
-    width: 100vw;
 }
 p, h3{
     color: white;
 }
+
 ul{
     display: flex;
-    gap: 2vw;
+    gap: 4vw;
     overflow-x: auto;
     overflow-y: hidden;
-    width: 95%;
-    height: 22vh;
+    width: 100%;
+    height: 25vh;
 }
 li{
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 0.5vh;
+    height: 25vh;
 }
 
 img{
-    height: 80%;
-    max-width: 25vw;
+    height: 90%;
+    width: auto;
+}
+
+@media screen and(min-width: 650px){
+    ul{
+        gap: 1vw;
+    }
 }

--- a/ThunderStrikes/src/app/modules/individual-movie/components/cast-and-crew/cast-and-crew.component.ts
+++ b/ThunderStrikes/src/app/modules/individual-movie/components/cast-and-crew/cast-and-crew.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Cast } from 'src/app/shared/interfaces/cast-and-crew.interface';
+import { ImageSize } from 'src/app/shared/interfaces/image-size.interface';
 import { MovieDetails } from 'src/app/shared/interfaces/tmdb.interface';
 import { MovieCreditsService } from 'src/app/shared/services/movie-credits.service';
+import { SharedApiDataService } from 'src/app/shared/services/shared-api-data.service';
 
 @Component({
   selector: 'app-cast-and-crew',
@@ -12,7 +14,12 @@ import { MovieCreditsService } from 'src/app/shared/services/movie-credits.servi
 export class CastAndCrewComponent implements OnInit {
   @Input() movie!: MovieDetails;
   cast$!: Observable<Cast[]>;
-  constructor(private readonly movieCreditsService: MovieCreditsService) {
+  readonly actorImageSize: ImageSize;
+  constructor(
+    private readonly movieCreditsService: MovieCreditsService,
+    private readonly sharedApiService: SharedApiDataService,) {
+    this.actorImageSize = this.sharedApiService.actorImageSize;
+
    }
 
   ngOnInit(): void {

--- a/ThunderStrikes/src/app/modules/individual-movie/components/genres/genres.component.scss
+++ b/ThunderStrikes/src/app/modules/individual-movie/components/genres/genres.component.scss
@@ -18,3 +18,9 @@ li{
     padding: 1.75vw;
     border-radius: 0.75vw;
 }
+
+@media screen and(min-width: 650px){
+    li{
+        padding: 0.75vw;
+    }
+}

--- a/ThunderStrikes/src/app/modules/individual-movie/components/individual-movie/individual-movie.component.html
+++ b/ThunderStrikes/src/app/modules/individual-movie/components/individual-movie/individual-movie.component.html
@@ -1,7 +1,12 @@
 
 <main class="container" *ngIf="movie">
     <div class="movie-image-container">
-        <img src="{{movie.poster_path}}" alt="{{movie.title}} poster image.">
+        <img
+            [src]="properImage" 
+            alt="{{movie.title}} poster image."
+            width="{{posterSize.width}}"
+            height="{{posterSize.height}}"
+            >
     </div>
     <div class="movie-content">
         <app-movie-tags [movie]="movie"></app-movie-tags>

--- a/ThunderStrikes/src/app/modules/individual-movie/components/individual-movie/individual-movie.component.ts
+++ b/ThunderStrikes/src/app/modules/individual-movie/components/individual-movie/individual-movie.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { ImageSize } from 'src/app/shared/interfaces/image-size.interface';
 import { MovieDetails } from 'src/app/shared/interfaces/tmdb.interface';
+import { ScreenSizeService } from 'src/app/shared/services/screen-size.service';
+import { SharedApiDataService } from 'src/app/shared/services/shared-api-data.service';
 import { TmdbApiService } from 'src/app/shared/services/tmdb-api.service';
 
 @Component({
@@ -10,14 +13,22 @@ import { TmdbApiService } from 'src/app/shared/services/tmdb-api.service';
 })
 export class IndividualMovieComponent implements OnInit {
   movie!: MovieDetails;
+  readonly posterSize: ImageSize;
+  readonly screenSize: string;
+  properImage: string = "";
   constructor(
     private readonly tmdbService: TmdbApiService,
     private readonly activatedRoute: ActivatedRoute,
+    private readonly sharedApiService: SharedApiDataService,
+    private readonly screenSizeService: ScreenSizeService,
   ) {
+    this.posterSize = this.sharedApiService.posterSize;
+    this.screenSize = this.screenSizeService.screenSizeUsed;
     this.activatedRoute.paramMap.subscribe(params => {
       const id: string = params.get("id") as string;
-      this.tmdbService.getMovie(Number(id)).subscribe(data => {
+      this.tmdbService.getMovie(id).subscribe(data => {
         this.movie = data;
+        this.properImage = this.screenSize === "mobile" ? this.movie.poster_path : this.movie.backdrop_path;
       });
     });
   }

--- a/ThunderStrikes/src/app/shared/interfaces/image-size.interface.ts
+++ b/ThunderStrikes/src/app/shared/interfaces/image-size.interface.ts
@@ -1,0 +1,4 @@
+export interface ImageSize{
+    width: number,
+    height: number,
+}

--- a/ThunderStrikes/src/app/shared/interfaces/screen-sizes.interface.ts
+++ b/ThunderStrikes/src/app/shared/interfaces/screen-sizes.interface.ts
@@ -1,0 +1,5 @@
+export interface ScreenSize{
+    mobile: string,
+    tablet: string,
+    computer: string,
+}

--- a/ThunderStrikes/src/app/shared/services/movie-credits.service.ts
+++ b/ThunderStrikes/src/app/shared/services/movie-credits.service.ts
@@ -9,7 +9,7 @@ import { SharedApiDataService } from './shared-api-data.service';
   providedIn: 'root'
 })
 export class MovieCreditsService {
-  private readonly castCount: number = 10;
+  private readonly castCount: number = 15;
   constructor(
     private readonly httpClient: HttpClient,
     private readonly sharedApiService: SharedApiDataService,
@@ -18,11 +18,18 @@ export class MovieCreditsService {
   getCast(id: number): Observable<Cast[]>{
     return this.httpClient.get([this.sharedApiService.baseUrl, id, MovieOptions.Cast].join("/"), { headers: this.sharedApiService.httpHeaders }).pipe(
       <any>map((data: CastAndCrew) => {
-        const cast = data.cast.slice(0, this.castCount);
+        let cast: Cast[] = [];
+        if(data.cast.length > this.castCount){
+          cast = data.cast.slice(0, this.castCount);
+        }
+        // We only want to display cast members
+        // that include a profile photo.
+        cast = cast.filter(withPicture => withPicture.profile_path);
         cast.map(data => {
           data.profile_path = this.sharedApiService.getActorImageUrl(data.profile_path);
           return data;
         });
+
         return cast;
       })
     );

--- a/ThunderStrikes/src/app/shared/services/screen-size.service.ts
+++ b/ThunderStrikes/src/app/shared/services/screen-size.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { ScreenSize } from '../interfaces/screen-sizes.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ScreenSizeService {
+  readonly screenSizes: ScreenSize = {mobile: "(max-width: 649px)", tablet: "(min-width: 650px) and (max-width: 1023px)", computer: "(min-width: 1024px)"};
+  constructor() { }
+  get screenSizeUsed(){
+    let screenSize: string = "";
+    for(let device in this.screenSizes){
+      const size = window.matchMedia(this.screenSizes[device as keyof ScreenSize]).matches;
+      if(size){
+        screenSize = device;
+        break;
+      }
+    }
+    return screenSize;
+  }
+}

--- a/ThunderStrikes/src/app/shared/services/shared-api-data.service.ts
+++ b/ThunderStrikes/src/app/shared/services/shared-api-data.service.ts
@@ -1,5 +1,6 @@
 import { HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { ImageSize } from '../interfaces/image-size.interface';
 import { MovieDetails } from '../interfaces/tmdb.interface';
 
 @Injectable({
@@ -9,15 +10,16 @@ export class SharedApiDataService {
   readonly baseUrl: string = "https://api.themoviedb.org/3/movie";
   readonly apiToken: string = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI2NGY0NGYxZDUyZjk0OTNiNjdkZjQzYWQ2MTk0MWQ0YiIsInN1YiI6IjYyY2ZjNzQ0MGI1ZmQ2MDA1Mzg3OTllMSIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.fslcsTZH_p1LHoiIFiOwqUYgkev98ZoFxOg3Epf9mlc";
   readonly imageUrlPath: string = "https://image.tmdb.org/t/p";
-  readonly posterWidth: number = 500;
-  readonly backdropWidth: number = 1280;
+  readonly posterSize: ImageSize = {width: 780, height: 1170};
+  readonly actorImageSize: ImageSize = {width: 342, height: 513};
+  readonly backdropWidth: ImageSize = {width: 1280, height: 720};
   readonly httpHeaders: HttpHeaders = new HttpHeaders({
     'Authorization': 'Bearer ' + this.apiToken,
     'Content-Type': 'application/json;charset=utf-8'
   });
   constructor() { }
   getActorImageUrl(imagePath: string) {
-    return [this.imageUrlPath, "w500", imagePath].join("/");
+    return this.imageUrlPath + "/w" + this.actorImageSize.width + imagePath;
   }
 
   // option for original quality because the images
@@ -29,8 +31,9 @@ export class SharedApiDataService {
       movie.poster_path = [this.imageUrlPath, "original", movie.poster_path].join("/");
       movie.backdrop_path = [this.imageUrlPath, "original" + movie.backdrop_path].join("/");
     } else {
-      movie.poster_path = [this.imageUrlPath, "w" + this.posterWidth, movie.poster_path].join("/");
-      movie.backdrop_path = [this.imageUrlPath, "w" + this.backdropWidth + movie.backdrop_path].join("/");
+      movie.poster_path = this.imageUrlPath + "/w" + this.posterSize.width + movie.poster_path;
+      movie.backdrop_path = this.imageUrlPath + "/w" + this.backdropWidth.width + movie.backdrop_path;
     }
   }
+
 }

--- a/ThunderStrikes/src/app/shared/services/tmdb-api.service.ts
+++ b/ThunderStrikes/src/app/shared/services/tmdb-api.service.ts
@@ -14,10 +14,10 @@ export class TmdbApiService {
     private readonly sharedApiService: SharedApiDataService,
   ) {}
 
-  getMovie(id: number): Observable<MovieDetails> {
-    return this.httpClient.get([this.sharedApiService.baseUrl, id].join('/'), { headers: this.sharedApiService.httpHeaders }).pipe(
+  getMovie(id: number | string): Observable<MovieDetails> {
+    return this.httpClient.get([this.sharedApiService.baseUrl, Number(id)].join('/'), { headers: this.sharedApiService.httpHeaders }).pipe(
       <any>map((movie: MovieDetails) => {
-        this.sharedApiService.setMovieImageUrl(movie, true);
+        this.sharedApiService.setMovieImageUrl(movie);
         return movie;
       })
     ) as Observable<MovieDetails>;

--- a/ThunderStrikes/src/index.html
+++ b/ThunderStrikes/src/index.html
@@ -5,6 +5,7 @@
   <title>ThunderStrikes</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Fast 4K movie streaming site with beautiful UI.">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="black">

--- a/ThunderStrikes/src/styles.scss
+++ b/ThunderStrikes/src/styles.scss
@@ -3,6 +3,9 @@
     --theme-color-accent: blue;
     --color-font-button: white;
 }
+$tablet-size: 600px;
+$laptop-size: 1024px;
+
 body{
     background-color: black;
 }


### PR DESCRIPTION
**Known issue:** Changing the background image from the more mobile suited `poster_path` to the tablet/desktop equivalent of `backdrop_path` is tedious to do on the fly. Currently only works on a page refresh.